### PR TITLE
Move the work for setting up the code coverage into a separate file

### DIFF
--- a/templates/ios/Example/Podfile
+++ b/templates/ios/Example/Podfile
@@ -10,26 +10,9 @@ target '${POD_NAME}_Tests', :exclusive => true do
   ${INCLUDED_PODS}
 end
 
-# Add ${POD_NAME} target to build step of the example project
+# Add a ${POD_NAME} target to the build steps of the example project
 # so that we get code coverage reports for ${POD_NAME}
 post_install do |installer|
-  # get ${POD_NAME} target from Pods project
-  pods_project = installer.pods_project
-  pods_targets = pods_project.targets
-  pod_target = pods_targets.select { |target| target.name == "${POD_NAME}" }.uniq.first
-
-  # get example project scheme
-  example_project = installer.aggregate_targets.map(&:user_project_path).uniq.first
-  example_shared_data_dir = Xcodeproj::XCScheme.shared_data_dir(example_project)
-  example_scheme_filename = "${POD_NAME}-Example.xcscheme"
-  example_scheme = Xcodeproj::XCScheme.new File.join(example_shared_data_dir, example_scheme_filename)
-
-  # create a build action that points to the pod target
-  pod_build_action_entry = Xcodeproj::XCScheme::BuildAction::Entry.new pod_target
-
-  # add the pod build action to the example project's build actions
-  example_build_action = example_scheme.build_action
-  example_build_action.add_entry(pod_build_action_entry)
-
-  example_scheme.save!
+  require_relative "Tests/setup_code_coverage.rb"
+  enable_code_coverage "${POD_NAME}", installer
 end

--- a/templates/ios/Example/Tests/setup_code_coverage.rb
+++ b/templates/ios/Example/Tests/setup_code_coverage.rb
@@ -1,0 +1,23 @@
+# Keeps the Podfile simple and to the point
+
+def enable_code_coverage(name, installer)
+  # get the library's target from Pods project
+  pods_project = installer.pods_project
+  pods_targets = pods_project.targets
+  pod_target = pods_targets.find { |target| target.name == name }
+
+  # get the example's project scheme
+  example_project = installer.aggregate_targets.map(&:user_project_path).uniq.first
+  example_shared_data_dir = Xcodeproj::XCScheme.shared_data_dir(example_project)
+  example_scheme_filename = "#{name}-Example.xcscheme"
+  example_scheme = Xcodeproj::XCScheme.new File.join(example_shared_data_dir, example_scheme_filename)
+
+  # create a build action that points to the pod target
+  pod_build_action_entry = Xcodeproj::XCScheme::BuildAction::Entry.new pod_target
+
+  # add the pod build action to the example project's build actions
+  example_build_action = example_scheme.build_action
+  example_build_action.add_entry(pod_build_action_entry)
+
+  example_scheme.save!
+end

--- a/templates/swift/Example/Podfile
+++ b/templates/swift/Example/Podfile
@@ -10,26 +10,9 @@ target '${POD_NAME}_Tests', :exclusive => true do
   ${INCLUDED_PODS}
 end
 
-# Add ${POD_NAME} target to build step of the example project
+# Add a ${POD_NAME} target to the build steps of the example project
 # so that we get code coverage reports for ${POD_NAME}
 post_install do |installer|
-  # get ${POD_NAME} target from Pods project
-  pods_project = installer.pods_project
-  pods_targets = pods_project.targets
-  pod_target = pods_targets.select { |target| target.name == "${POD_NAME}" }.uniq.first
-
-  # get example project scheme
-  example_project = installer.aggregate_targets.map(&:user_project_path).uniq.first
-  example_shared_data_dir = Xcodeproj::XCScheme.shared_data_dir(example_project)
-  example_scheme_filename = "${POD_NAME}-Example.xcscheme"
-  example_scheme = Xcodeproj::XCScheme.new File.join(example_shared_data_dir, example_scheme_filename)
-
-  # create a build action that points to the pod target
-  pod_build_action_entry = Xcodeproj::XCScheme::BuildAction::Entry.new pod_target
-
-  # add the pod build action to the example project's build actions
-  example_build_action = example_scheme.build_action
-  example_build_action.add_entry(pod_build_action_entry)
-
-  example_scheme.save!
+  require_relative "Tests/setup_code_coverage.rb"
+  enable_code_coverage "${POD_NAME}", installer
 end

--- a/templates/swift/Example/Tests/setup_code_coverage.rb
+++ b/templates/swift/Example/Tests/setup_code_coverage.rb
@@ -1,0 +1,23 @@
+# Keeps the Podfile simple and to the point
+
+def enable_code_coverage(name, installer)
+  # get the library's target from Pods project
+  pods_project = installer.pods_project
+  pods_targets = pods_project.targets
+  pod_target = pods_targets.find { |target| target.name == name }
+
+  # get the example's project scheme
+  example_project = installer.aggregate_targets.map(&:user_project_path).uniq.first
+  example_shared_data_dir = Xcodeproj::XCScheme.shared_data_dir(example_project)
+  example_scheme_filename = "#{name}-Example.xcscheme"
+  example_scheme = Xcodeproj::XCScheme.new File.join(example_shared_data_dir, example_scheme_filename)
+
+  # create a build action that points to the pod target
+  pod_build_action_entry = Xcodeproj::XCScheme::BuildAction::Entry.new pod_target
+
+  # add the pod build action to the example project's build actions
+  example_build_action = example_scheme.build_action
+  example_build_action.add_entry(pod_build_action_entry)
+
+  example_scheme.save!
+end


### PR DESCRIPTION
Makes the user-visible Podfile simpler.

I'm going to provide some PR feedback in https://github.com/CocoaPods/pod-template/pull/136
